### PR TITLE
Added Blaze's launchers, strings

### DIFF
--- a/VirtuaPartner/configs/blaze.txt
+++ b/VirtuaPartner/configs/blaze.txt
@@ -1,6 +1,26 @@
 Bla[z]e
 
-### Blaze's moves that have guaranteed punish
+### Launchers
+4+P+K	# -6
+8+P+K	# -9
+2__6+P+K	# -8, high
+1+P+K	# -13
+4_1_2_3_6+PP__	# -13, hit Blaze out of roll
+6+K+G	# -15
+
+### Strings
+46+PPK		#hhh
+46+PP__2+K	#hhl
+46+PKK__	#hmm
+KKK__		#hmh
+4+PKP__		#hmh
+4+KPP__		#mhm
+4+KPK__		#mhh
+2+KPP__		#lhh
+2+KPK__		#lhm
+P+KPP__		#hhm
+
+### Blaze's moves that have Guaranteed punish
 9+GP
 6+K+G #VolcanoKnee
 6+PK #ElbowKnee
@@ -19,7 +39,7 @@ PPK
 41236+P5P
 4+KP5P
 
-# Need to add #recoverslow tag for low moves which are
+# Need to add #recoverslow taG for low moves which are
 # not knee counterable so that Virtua Partner knows
 # to check for elbow counter instead
 6+P+K+G552+K #recoverslow

--- a/VirtuaPartner/configs/blaze.txt
+++ b/VirtuaPartner/configs/blaze.txt
@@ -39,7 +39,7 @@ PPK
 41236+P5P
 4+KP5P
 
-# Need to add #recoverslow taG for low moves which are
+# Need to add #recoverslow tag for low moves which are
 # not knee counterable so that Virtua Partner knows
 # to check for elbow counter instead
 6+P+K+G552+K #recoverslow


### PR DESCRIPTION
I added a curated list Blaze's launchers and strings to his command list. The launchers are in order of safest to least safe.

Some strings need a __ after the last command to prevent Virtua Partner's auto guard to cancel the string. I confirmed Virtua Partner still guards as soon as possible so that punishes remain accurate.